### PR TITLE
FEC-11018 - [Youbora][Android] Enable the parse.manifest option

### DIFF
--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
@@ -68,6 +68,8 @@ import static com.npaw.youbora.lib6.plugin.Options.KEY_ENABLED;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_USERNAME;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_USER_EMAIL;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_USER_TYPE;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_MANIFEST;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_NODE;
 
 @SuppressWarnings("unused")
 public class PKPlayerWrapper {
@@ -628,6 +630,11 @@ public class PKPlayerWrapper {
             if (wrapperYouboraConfig.getAppReleaseVersion() != null) {
                 optBundle.putString(KEY_APP_RELEASE_VERSION, wrapperYouboraConfig.getAppReleaseVersion());
             }
+
+            optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.isPasrseManifest());
+
+            optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.isPasrseCdnNode());
+
             if (wrapperYouboraConfig.getHouseHoldId() != null) {
                 optBundle.putString(KEY_HOUSEHOLD_ID, wrapperYouboraConfig.getHouseHoldId());
             }

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
@@ -631,9 +631,9 @@ public class PKPlayerWrapper {
                 optBundle.putString(KEY_APP_RELEASE_VERSION, wrapperYouboraConfig.getAppReleaseVersion());
             }
 
-            optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.isPasrseManifest());
+            optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.isParseManifest());
 
-            optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.isPasrseCdnNode());
+            optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.isParseCdnNode());
 
             if (wrapperYouboraConfig.getHouseHoldId() != null) {
                 optBundle.putString(KEY_HOUSEHOLD_ID, wrapperYouboraConfig.getHouseHoldId());

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
@@ -157,9 +157,12 @@ public class PKPlayerWrapper {
                 }
 
                 if (initOptionsModel.plugins.youbora != null) {
-                    JsonObject accountCode = initOptionsModel.plugins.youbora;
-                    if (accountCode.has(YOUBORA_ACCOUNT_CODE) && accountCode.get(YOUBORA_ACCOUNT_CODE) != null) {
-                        createYouboraPlugin(pluginConfigs, new WrapperYouboraConfig().setAccountCode(accountCode.get(YOUBORA_ACCOUNT_CODE).getAsString()));
+                    JsonObject youboraConfigJson = initOptionsModel.plugins.youbora;
+                    if (youboraConfigJson.has(YOUBORA_ACCOUNT_CODE) && youboraConfigJson.get(YOUBORA_ACCOUNT_CODE) != null) {
+                        WrapperYouboraConfig wrapperYouboraConfig = gson.fromJson(youboraConfigJson, WrapperYouboraConfig.class);
+                        if (wrapperYouboraConfig != null) {
+                            createYouboraPlugin(pluginConfigs, wrapperYouboraConfig);
+                        }
                     }
                 }
 
@@ -170,7 +173,7 @@ public class PKPlayerWrapper {
                 if (initOptionsModel.plugins.broadpeak != null) {
                     JsonObject broadpeakJsonObject = initOptionsModel.plugins.broadpeak;
 
-                    BroadpeakConfig broadpeakConfig = new Gson().fromJson(broadpeakJsonObject.toString(), BroadpeakConfig.class);
+                    BroadpeakConfig broadpeakConfig = gson.fromJson(broadpeakJsonObject.toString(), BroadpeakConfig.class);
                     createBroadpeakPlugin(pluginConfigs, broadpeakConfig);
                 }
             }
@@ -627,13 +630,14 @@ public class PKPlayerWrapper {
             if (wrapperYouboraConfig.getAppName() != null) {
                 optBundle.putString(KEY_APP_NAME, wrapperYouboraConfig.getAppName());
             }
+
             if (wrapperYouboraConfig.getAppReleaseVersion() != null) {
                 optBundle.putString(KEY_APP_RELEASE_VERSION, wrapperYouboraConfig.getAppReleaseVersion());
             }
 
-            optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.isParseManifest());
+            optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.getParseManifest());
 
-            optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.isParseCdnNode());
+            optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.getParseCdnNode());
 
             if (wrapperYouboraConfig.getHouseHoldId() != null) {
                 optBundle.putString(KEY_HOUSEHOLD_ID, wrapperYouboraConfig.getHouseHoldId());
@@ -908,3 +912,4 @@ public class PKPlayerWrapper {
         sendPlayerEvent(type, null);
     }
 }
+

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
@@ -31,8 +31,8 @@ import com.kaltura.playkit.plugins.broadpeak.BroadpeakPlugin;
 import com.kaltura.playkit.plugins.ima.IMAConfig;
 import com.kaltura.playkit.plugins.ima.IMAPlugin;
 import com.kaltura.playkit.plugins.ott.PhoenixAnalyticsConfig;
-import com.kaltura.playkit.plugins.ott.PhoenixAnalyticsPlugin;
 import com.kaltura.playkit.plugins.ott.PhoenixAnalyticsEvent;
+import com.kaltura.playkit.plugins.ott.PhoenixAnalyticsPlugin;
 import com.kaltura.playkit.plugins.youbora.YouboraPlugin;
 import com.kaltura.playkit.utils.Consts;
 import com.kaltura.tvplayer.KalturaOttPlayer;
@@ -65,11 +65,15 @@ import static com.npaw.youbora.lib6.plugin.Options.KEY_APP_RELEASE_VERSION;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_CUSTOM_DIMENSION_1;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_CUSTOM_DIMENSION_2;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_ENABLED;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_NAME_HEADER;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_NODE;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_NODE_LIST;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_SWITCH_HEADER;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_TTL;
+import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_MANIFEST;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_USERNAME;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_USER_EMAIL;
 import static com.npaw.youbora.lib6.plugin.Options.KEY_USER_TYPE;
-import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_MANIFEST;
-import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_NODE;
 
 @SuppressWarnings("unused")
 public class PKPlayerWrapper {
@@ -635,9 +639,29 @@ public class PKPlayerWrapper {
                 optBundle.putString(KEY_APP_RELEASE_VERSION, wrapperYouboraConfig.getAppReleaseVersion());
             }
 
-            optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.getParseManifest());
+            if (wrapperYouboraConfig.getParseManifest() != null) {
+                optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.getParseManifest());
+            }
 
-            optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.getParseCdnNode());
+            if (wrapperYouboraConfig.getParseCdnNode() != null) {
+                optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.getParseCdnNode());
+            }
+
+            if (wrapperYouboraConfig.getCdnNodeList() != null) {
+                optBundle.putStringArrayList(KEY_PARSE_CDN_NODE_LIST, wrapperYouboraConfig.getCdnNodeList());
+            }
+
+            if (wrapperYouboraConfig.getCdnNameHeaders() != null) {
+                optBundle.putString(KEY_PARSE_CDN_NAME_HEADER, wrapperYouboraConfig.getCdnNameHeaders());
+            }
+
+            if (wrapperYouboraConfig.getParseCdnSwitchHeader() != null) {
+                optBundle.putBoolean(KEY_PARSE_CDN_SWITCH_HEADER, wrapperYouboraConfig.getParseCdnSwitchHeader());
+            }
+
+            if (wrapperYouboraConfig.getParseCdnTTL() != null) {
+                optBundle.putInt(KEY_PARSE_CDN_TTL, wrapperYouboraConfig.getParseCdnTTL());
+            }
 
             if (wrapperYouboraConfig.getHouseHoldId() != null) {
                 optBundle.putString(KEY_HOUSEHOLD_ID, wrapperYouboraConfig.getHouseHoldId());

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
@@ -634,35 +634,27 @@ public class PKPlayerWrapper {
             if (wrapperYouboraConfig.getAppName() != null) {
                 optBundle.putString(KEY_APP_NAME, wrapperYouboraConfig.getAppName());
             }
-
             if (wrapperYouboraConfig.getAppReleaseVersion() != null) {
                 optBundle.putString(KEY_APP_RELEASE_VERSION, wrapperYouboraConfig.getAppReleaseVersion());
             }
-
             if (wrapperYouboraConfig.getParseManifest() != null) {
                 optBundle.putBoolean(KEY_PARSE_MANIFEST, wrapperYouboraConfig.getParseManifest());
             }
-
             if (wrapperYouboraConfig.getParseCdnNode() != null) {
                 optBundle.putBoolean(KEY_PARSE_CDN_NODE, wrapperYouboraConfig.getParseCdnNode());
             }
-
             if (wrapperYouboraConfig.getCdnNodeList() != null) {
                 optBundle.putStringArrayList(KEY_PARSE_CDN_NODE_LIST, wrapperYouboraConfig.getCdnNodeList());
             }
-
             if (wrapperYouboraConfig.getCdnNameHeaders() != null) {
                 optBundle.putString(KEY_PARSE_CDN_NAME_HEADER, wrapperYouboraConfig.getCdnNameHeaders());
             }
-
             if (wrapperYouboraConfig.getParseCdnSwitchHeader() != null) {
                 optBundle.putBoolean(KEY_PARSE_CDN_SWITCH_HEADER, wrapperYouboraConfig.getParseCdnSwitchHeader());
             }
-
             if (wrapperYouboraConfig.getParseCdnTTL() != null) {
                 optBundle.putInt(KEY_PARSE_CDN_TTL, wrapperYouboraConfig.getParseCdnTTL());
             }
-
             if (wrapperYouboraConfig.getHouseHoldId() != null) {
                 optBundle.putString(KEY_HOUSEHOLD_ID, wrapperYouboraConfig.getHouseHoldId());
             }

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
@@ -10,6 +10,10 @@ public class WrapperYouboraConfig {
 
     private String userType;        // any string - free / paid etc.
 
+    private boolean pasrseManifest = false;
+
+    private boolean pasrseCdnNode = false;
+
     private String houseHoldId;    // which device is used to play
 
     private boolean httpSecure = true; // youbora events will be sent via https
@@ -43,6 +47,14 @@ public class WrapperYouboraConfig {
         return userType;
     }
 
+    public boolean isPasrseManifest() {
+        return pasrseManifest;
+    }
+
+    public boolean isPasrseCdnNode() {
+        return pasrseCdnNode;
+    }
+
     public String getHouseHoldId() {
         return houseHoldId;
     }
@@ -67,3 +79,4 @@ public class WrapperYouboraConfig {
         return extraParam2;
     }
 }
+

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
@@ -1,5 +1,7 @@
 package tv.youi.kalturaplayeryoui.model;
 
+import java.util.ArrayList;
+
 public class WrapperYouboraConfig {
 
     private String accountCode;
@@ -10,9 +12,17 @@ public class WrapperYouboraConfig {
 
     private String userType;        // any string - free / paid etc.
 
-    private boolean parseManifest;
+    private Boolean parseManifest;
 
-    private boolean parseCdnNode;
+    private Boolean parseCdnNode;
+
+    private Boolean parseCdnSwitchHeader;
+
+    private ArrayList<String> cdnNodeList;
+
+    private String cdnNameHeaders;
+
+    private Integer parseCdnTTL;
 
     private String houseHoldId;    // which device is used to play
 
@@ -47,12 +57,28 @@ public class WrapperYouboraConfig {
         return userType;
     }
 
-    public boolean getParseManifest() {
+    public Boolean getParseManifest() {
         return parseManifest;
     }
 
-    public boolean getParseCdnNode() {
+    public Boolean getParseCdnNode() {
         return parseCdnNode;
+    }
+
+    public Boolean getParseCdnSwitchHeader() {
+        return parseCdnSwitchHeader;
+    }
+
+    public ArrayList<String> getCdnNodeList() {
+        return cdnNodeList;
+    }
+
+    public String getCdnNameHeaders() {
+        return cdnNameHeaders;
+    }
+
+    public Integer getParseCdnTTL() {
+        return parseCdnTTL;
     }
 
     public String getHouseHoldId() {

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
@@ -10,9 +10,9 @@ public class WrapperYouboraConfig {
 
     private String userType;        // any string - free / paid etc.
 
-    private boolean pasrseManifest = false;
+    private boolean parseManifest;
 
-    private boolean pasrseCdnNode = false;
+    private boolean parseCdnNode;
 
     private String houseHoldId;    // which device is used to play
 
@@ -47,12 +47,12 @@ public class WrapperYouboraConfig {
         return userType;
     }
 
-    public boolean isPasrseManifest() {
-        return pasrseManifest;
+    public boolean isParseManifest() {
+        return parseManifest;
     }
 
-    public boolean isPasrseCdnNode() {
-        return pasrseCdnNode;
+    public boolean isParseCdnNode() {
+        return parseCdnNode;
     }
 
     public String getHouseHoldId() {

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/WrapperYouboraConfig.java
@@ -47,11 +47,11 @@ public class WrapperYouboraConfig {
         return userType;
     }
 
-    public boolean isParseManifest() {
+    public boolean getParseManifest() {
         return parseManifest;
     }
 
-    public boolean isParseCdnNode() {
+    public boolean getParseCdnNode() {
         return parseCdnNode;
     }
 


### PR DESCRIPTION
add support in setting KEY_PARSE_MANIFEST and KEY_PARSE_CDN_NODE to true

import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_MANIFEST;
import static com.npaw.youbora.lib6.plugin.Options.KEY_PARSE_CDN_NODE;

example:

```
"plugins": {
                    "ima": {},
                    "youbora": {
                        "accountCode": "testtest",
                        "username": "aaa",
                        "userEmail": "aaa@gmail.com",
                        "parseManifest": true,
                        "parseCdnNode": false,
                        "userType": "paid",       // optional any string - free / paid etc.
                        "houseHoldId": "qwerty",   // optional which device is used to play
                        "httpSecure": true,        // youbora events will be sent via https
                        "appName": "YouiBridgeTesdtApp",
                        "appReleaseVersion": "v1.0.0",
                    }
                }
```