### PR TITLE
feat(FEC-10996): [AN] add support in PKRequestConfiguration

### DIFF
--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/PKPlayerWrapper.java
@@ -167,7 +167,11 @@ public class PKPlayerWrapper {
         final PlayerInitOptions initOptions = new PlayerInitOptions(partnerId);
         initOptions.setAutoPlay(initOptionsModel.autoplay);
         initOptions.setPreload(initOptionsModel.preload);
-        initOptions.setAllowCrossProtocolEnabled(initOptionsModel.allowCrossProtocolRedirect);
+        if (initOptionsModel.requestConfiguration != null) {
+            initOptions.setPKRequestConfig(initOptionsModel.requestConfiguration);
+        } else {
+            initOptions.setAllowCrossProtocolEnabled(initOptionsModel.allowCrossProtocolRedirect);
+        }
         initOptions.setKs(initOptionsModel.ks);
         initOptions.setReferrer(initOptionsModel.referrer);
         initOptions.setAbrSettings(initOptionsModel.abrSettings);

--- a/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/InitOptions.java
+++ b/android/modules/KalturaPlayer/src/main/java/tv/youi/kalturaplayeryoui/model/InitOptions.java
@@ -1,6 +1,7 @@
 package tv.youi.kalturaplayeryoui.model;
 
 import com.kaltura.playkit.PKMediaFormat;
+import com.kaltura.playkit.PKRequestConfiguration;
 import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 import com.kaltura.playkit.player.PKMaxVideoSize;
@@ -17,6 +18,7 @@ public class InitOptions {
     public List<String> warmupUrls;
     public String ks;
     public String referrer;
+    public PKRequestConfiguration requestConfiguration;
     public ABRSettings abrSettings;
     public NetworkSettings networkSettings;
     public TrackSelection trackSelection;


### PR DESCRIPTION

configure crossProtocolRedirectEnabled, readTimeoutMs, connectTimeoutMs

### NEW
```
"requestConfiguration": {
                    "crossProtocolRedirectEnabled": true,
                    "readTimeoutMs": 8000,
                    "connectTimeoutMs": 8000
 }   
```            
### DEPRECATED 
```
 "allowCrossProtocolRedirect": true,  
 ```               
           